### PR TITLE
Add note about CVE-2021-44228 and bump example app dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 
 # IntelliJ
 .idea/
+
+### Java ###
+# Compiled class file
+*.class

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ on [the Log4j website](https://logging.apache.org/log4j/2.x/manual/extending.htm
 
 * Java 8 or later
 * Log4j 2, version 2.13.2 or later
+  * ⚠ If you use any version <= 2.14.1 pay attention to the Log4j vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) and its mitigation, ideally update to 2.15.+
 * OpenTelemetry (tested with 1.4, but we suggest using the latest 1.+ version)
 
 ## Installation
@@ -17,9 +18,10 @@ In order to add Metadata to Log4j log lines, include the following dependencies 
 
 ```groovy
 // Depend on log4j itself, this is probably already in your project.
-// The mechanism that is used in this library works from v2.13.2
-implementation("org.apache.logging.log4j:log4j-api:2.14.1")
-implementation("org.apache.logging.log4j:log4j-core:2.14.1")
+// The mechanism that is used in this library works from v2.13.2.
+// If you use any version <= 2.14.1 pay attention to the Log4j vulnerability CVE-2021-44228 and its mitigation.
+implementation("org.apache.logging.log4j:log4j-api:2.15.+")
+implementation("org.apache.logging.log4j:log4j-core:2.15.+")
 
 runtimeOnly("com.dynatrace.logs.log4j2:metadata-provider:0.2.0")
 ```
@@ -295,7 +297,7 @@ ignored.
 
 ### Example with OpenTelemetry
 
-This [example](./example_with_otel) demonstrates how both Dynatrace and OpenTelemetry metadata are added to the logs. 
+This [example](./example_with_otel) demonstrates how both Dynatrace and OpenTelemetry metadata are added to the logs.
 Check out the `log4j2.xml` configuration file to see how the properties are configured.
 Dynatrace metadata is only added when a OneAgent is running on the host.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to add Metadata to Log4j log lines, include the following dependencies 
 implementation("org.apache.logging.log4j:log4j-api:2.15.+")
 implementation("org.apache.logging.log4j:log4j-core:2.15.+")
 
-runtimeOnly("com.dynatrace.logs.log4j2:metadata-provider:0.2.0")
+runtimeOnly("com.dynatrace.logs.log4j2:metadata-provider:0.2.1")
 ```
 
 As this library is not published on Maven Central, a source dependency is required.

--- a/example_with_otel/build.gradle
+++ b/example_with_otel/build.gradle
@@ -25,7 +25,7 @@ mainClassName = 'com.dynatrace.example.AppWithOpenTelemetry'
 version = "0.0.1"
 
 def otelVersion = '1.4.+'
-def log4jVersion = "2.14.+"
+def log4jVersion = "2.15.+"
 
 dependencies {
     // Log4j dependencies

--- a/example_without_otel/build.gradle
+++ b/example_without_otel/build.gradle
@@ -24,7 +24,7 @@ repositories {
 mainClassName = 'com.dynatrace.example.AppWithoutOpenTelemetry'
 version = "0.0.1"
 
-def log4jVersion = "2.14.+"
+def log4jVersion = "2.15.+"
 
 dependencies {
     // Log4j dependencies

--- a/metadata-provider/build.gradle
+++ b/metadata-provider/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.dynatrace.logs.log4j2'
-version = '0.2.0'
+version = '0.2.1'
 
 def otelVersion = '1.+'
 

--- a/metadata-provider/build.gradle
+++ b/metadata-provider/build.gradle
@@ -25,8 +25,9 @@ version = '0.2.0'
 
 def otelVersion = '1.+'
 
-// ContextDataProvider was introduced in log42 v2.13.2.
-// Therefore, use any version from (and including) 2.13.2 can be used
+// ContextDataProvider was introduced in log4j v2.13.2.
+// Therefore, any version from (and including) 2.13.2 can be used.
+// If you use any version <= 2.14.1 pay attention to the Log4j vulnerability CVE-2021-44228 and its mitigation.
 def log4jVersion = '[2.13.2, )'
 
 dependencies {


### PR DESCRIPTION
This metadata provider library is not susceptible to the Log4j vulnerability as we do not use Log4j for logging internally and don't expose any Log4j dependency to users but actually pick the one defined by them up. However we should instruct users accordingly and also use the fixed version in our example in case one would copy the dependency from there and add it to their app which might log user-provided input.